### PR TITLE
Fix: display validation messages and unique email except current user

### DIFF
--- a/src/Http/Controllers/ToolController.php
+++ b/src/Http/Controllers/ToolController.php
@@ -18,8 +18,9 @@ class ToolController extends Controller
               $field['value'] = auth()->user()->{$field['value']};
           }
 
-          $field['name'] = ucfirst(__("validation.attributes." . $field['attribute']));
-          $field['indexName'] = ucfirst(__("validation.attributes." . $field['attribute']));
+          $field['name'] = $field['name'] ?? ucfirst(__(str_replace('_',' ',$field['attribute'])));
+          $field['indexName'] = $field['indexName'] ?? ucfirst(__(str_replace('_',' ',$field['attribute'])));
+          $field['validationKey'] = $field['validationKey'] ?? $field['attribute'];
 
           $fields[] = $field;
         }
@@ -33,6 +34,11 @@ class ToolController extends Controller
     public function store()
     {
         $validations = config('nova-profile-tool.validations');
+
+        // unique email except auth user's email
+        if($validations['email']){
+            $validations['email'] = $validations['email'].'|unique:users,email,'.auth()->id();
+        }
 
         request()->validate($validations);
 


### PR DESCRIPTION
Fixes for https://github.com/runlinenl/nova-profile-tool/issues/20:
Validation errors are now displayed under each field. Fixed by adding `validationKey` on field 
Added unique rule excluding current user. Fixed by adding unique rule, it can't be added by config, as config doesn't have access to auth user.
![image](https://user-images.githubusercontent.com/7312456/87852346-c8020980-c91e-11ea-8f05-0b9b4795ce19.png)
![image](https://user-images.githubusercontent.com/7312456/87852360-df40f700-c91e-11ea-8085-7a9ac0c1bdec.png)
